### PR TITLE
haml関連のgemのインストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,3 +45,6 @@ group :development do
   gem 'spring'
 end
 
+gem "erb2haml", :group => :development
+
+gem "haml-rails", "~> 0.9"


### PR DESCRIPTION
# WHAT

haml関連のgemのインストール
haml-rails,erb2haml
# WHY

hamlテンプレートエンジンにより、HTMLのマークアップを行うため。
