### PR TITLE
ページネーション機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,3 +58,5 @@ gem 'pry-rails'
 gem 'carrierwave', github: 'carrierwaveuploader/carrierwave'
 
 gem 'rmagick', require: 'RMagick'
+
+gem 'kaminari'

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,6 +1,5 @@
 class PrototypesController < ApplicationController
   def index
-    # @protos = Prototype.includes(:images).order("id DESC").limit(6)
     @protos = Prototype.includes(:images).order("id DESC").page(params[:page])
   end
 

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,6 +1,7 @@
 class PrototypesController < ApplicationController
   def index
-    @protos = Prototype.includes(:images).order("id DESC").limit(6)
+    # @protos = Prototype.includes(:images).order("id DESC").limit(6)
+    @protos = Prototype.includes(:images).order("id DESC").page(params[:page])
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
 
   def show
     find_user
-    @protos = @user.prototypes.order("id DESC")
+    @protos = @user.prototypes.includes(:images).order("id DESC").page(params[:page])
   end
 
   def edit

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -1,0 +1,2 @@
+%li
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -1,2 +1,2 @@
-%li
-  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote
+/ %li
+/   = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -1,0 +1,2 @@
+%li.disabled
+  = content_tag :a, raw(t 'views.pagination.truncate')

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -1,0 +1,2 @@
+%li
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote}

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -1,2 +1,2 @@
-%li
-  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote}
+/ %li
+/   = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote}

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -1,0 +1,2 @@
+%li
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -1,2 +1,2 @@
 %li
-  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote
+  = link_to_unless current_page.last?, raw(t '>>'), url, :rel => 'next', :remote => remote

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -1,0 +1,6 @@
+- if page.current?
+  %li.active
+    = content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))
+- else
+  %li
+    = link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -1,0 +1,11 @@
+= paginator.render do
+  %ul.pagination
+    = first_page_tag unless current_page.first?
+    = prev_page_tag unless current_page.first?
+    - each_page do |page|
+      - if page.left_outer? || page.right_outer? || page.inside_window?
+        = page_tag page
+      - elsif !page.was_truncated?
+        = gap_tag
+    = next_page_tag unless current_page.last?
+    = last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -1,0 +1,2 @@
+%li
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -1,2 +1,2 @@
 %li
-  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote
+  = link_to_unless current_page.first?, raw(t '<<'), url, :rel => 'prev', :remote => remote

--- a/app/views/prototypes/index.html.haml
+++ b/app/views/prototypes/index.html.haml
@@ -14,22 +14,4 @@
   .row
     = render partial: "layouts/prototypes" , collection: @protos, as: :proto
 .text-center
-  %ul.pagination
-    %li.disabled
-      %a{"aria-label" => "Previous", href: "#"}
-        %span{"aria-hidden" => "true"} «
-    %li.active
-      %a{href: "#"}
-        1
-        %span.sr-only (current)
-    %li
-      %a{href: "#"} 2
-    %li
-      %a{href: "#"} 3
-    %li
-      %a{href: "#"} 4
-    %li
-      %a{href: "#"} 5
-    %li
-      %a{"aria-label": "Next", href: "#"}
-        %span{"aria-hidden": "true"} »
+  = paginate @protos

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -22,22 +22,4 @@
   .row
     = render partial: "layouts/prototypes" , collection: @protos, as: :proto
 .text-center
-  %ul.pagination
-    %li.disabled
-      %a{"aria-label": "Previous", href: "#"}
-        %span{"aria-hidden": "true"} «
-    %li.active
-      %a{href: "#"}
-        1
-        %span.sr-only (current)
-    %li
-      %a{href: "#"} 2
-    %li
-      %a{href: "#"} 3
-    %li
-      %a{href: "#"} 4
-    %li
-      %a{href: "#"} 5
-    %li
-      %a{"aria-label": "Next", href: "#"}
-        %span{"aria-hidden": "true"} »
+  = paginate @protos

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,10 @@
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,6 +1,6 @@
 Kaminari.configure do |config|
   # config.default_per_page = 25
-  config.default_per_page = 9
+  config.default_per_page = 8
   # config.max_per_page = nil
   # config.window = 4
   # config.outer_window = 0

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,5 +1,6 @@
 Kaminari.configure do |config|
   # config.default_per_page = 25
+  config.default_per_page = 9
   # config.max_per_page = nil
   # config.window = 4
   # config.outer_window = 0


### PR DESCRIPTION
# WHAT

Topのindexページとマイページのprototypeの一覧にネーション機能を追加する。
# WHY

たくさんのprototypeが合った場合に見やすくするため。
また、データを表示する量を減らして、ページを早く表示させ、UXをあげる。
